### PR TITLE
Refactor: 모달 코드 중복 개선 #383

### DIFF
--- a/my-app/src/components/postView/PostCard.jsx
+++ b/my-app/src/components/postView/PostCard.jsx
@@ -222,9 +222,6 @@ export default function PostCard({
             });
             setIsConfirmVisible(false);
             handleShowToast();
-            // setTimeout(function () {
-            //     navigate(-1); // 뒤로 가기
-            // }, 1500);
             deleteByUpper(data.id);
         } catch (err) {
             console.log(err);

--- a/my-app/src/hook/usePostDetail.js
+++ b/my-app/src/hook/usePostDetail.js
@@ -2,14 +2,14 @@ import axios from "axios";
 import { useCallback } from "react";
 
 export default function usePostDetail(reacts) {
-    const { setPostMsg, currentId, currentUserId } = reacts;
+    const { setPostMsg, id, currentUserId } = reacts;
 
     const sendRequest = useCallback(
         (commentsURL, applyData, isCommentLoading) => {
             const getComments = async () => {
                 try {
                     const postDetailURL =
-                        "https://mandarin.api.weniv.co.kr/post/" + currentId;
+                        "https://mandarin.api.weniv.co.kr/post/" + id;
                     const postDetailRes = await axios.get(postDetailURL, {
                         headers: {
                             Authorization:
@@ -27,7 +27,11 @@ export default function usePostDetail(reacts) {
                         },
                     });
 
-                    applyData(commentsRes, postDetailRes.data.post.commentCount, isCommentLoading);
+                    applyData(
+                        commentsRes,
+                        postDetailRes.data.post.commentCount,
+                        isCommentLoading
+                    );
                 } catch (err) {
                     console.log(err);
                 }
@@ -35,7 +39,7 @@ export default function usePostDetail(reacts) {
 
             getComments();
         },
-        [currentId, setPostMsg, currentUserId]
+        [id, setPostMsg, currentUserId]
     );
 
     return sendRequest;

--- a/my-app/src/pages/feed/post/CommentOptionModal.jsx
+++ b/my-app/src/pages/feed/post/CommentOptionModal.jsx
@@ -1,0 +1,34 @@
+import React from "react";
+import OptionModal from "../../../components/optionModal/OptionModal";
+
+export default function CommentOptionModal({
+    commentState,
+    setCommentState,
+    deleteTarget,
+    clickHandle,
+}) {
+    return (
+        <>
+            {commentState.isOpen && (
+                <OptionModal
+                    onConfirm={() => {
+                        setCommentState((prev) => ({
+                            ...prev,
+                            isMe: undefined,
+                            isOpen: false,
+                        }));
+                        deleteTarget.current = null;
+                    }}
+                >
+                    <li>
+                        <button type="button" onClick={clickHandle}>
+                            {commentState.isMe
+                                ? "댓글 삭제하기"
+                                : "댓글 신고하기"}
+                        </button>
+                    </li>
+                </OptionModal>
+            )}
+        </>
+    );
+}

--- a/my-app/src/pages/feed/post/PostOptionModal.jsx
+++ b/my-app/src/pages/feed/post/PostOptionModal.jsx
@@ -1,0 +1,39 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import OptionModal from "../../../components/optionModal/OptionModal";
+
+export default function PostOptionModal({
+    postState,
+    setPostState,
+    clickHandle,
+    postDetailId
+}) {
+    return (
+        <>
+            {postState.isOpen && (
+                <OptionModal
+                    onConfirm={() => {
+                        setPostState((prev) => ({
+                            ...prev,
+                            isMe: undefined,
+                            isOpen: false,
+                        }));
+                    }}
+                >
+                    <li>
+                        <button type="button" onClick={clickHandle}>
+                            {postState.isMe
+                                ? "삭제"
+                                : "신고"}
+                        </button>
+                    </li>
+                    {postState.isMe && (
+                        <li>
+                            <Link to={`/post/${postDetailId}/edit`}>수정</Link>
+                        </li>
+                    )}
+                </OptionModal>
+            )}
+        </>
+    );
+}

--- a/my-app/src/pages/profile/userprofile/Profile.jsx
+++ b/my-app/src/pages/profile/userprofile/Profile.jsx
@@ -39,7 +39,7 @@ export default function Profile() {
 
   useEffect(() => {
     data && setAccountName(data.accountname);
-  },[data])
+  },[data]);
 
   useEffect(() => {
     if (accoutName && !isMyProfile){
@@ -51,7 +51,7 @@ export default function Profile() {
       }
     }
     // eslint-disable-next-line
-  }, [accoutName, accountNameInURL])
+  }, [accoutName, accountNameInURL]);
 
 
   const onConfirm = () => {


### PR DESCRIPTION
# 수정 전 문제점
PostDetail.jsx에서 모달창 코드가 중복되는게 많았음

# 수정 페이지
PostDetail.jsx

# 특이사항
- PostDetail.jsx에서 post detail id를 가져올 때 useLocation 대신 useParams 이용
- pages/feed/post하에 CommentOptionModal.jsx와 PostOptionModal.jsx 추가
- PostDetail.jsx에서 댓글 모달과 포스트 모달의 state를 각각 객체로 관리함으로써 관리해야 할 state의 수를 줄임