### PR TITLE
Refactor: 프로필 페이지 - 판매 중인 상품 가격 text color 변경 #397

### DIFF
--- a/my-app/src/pages/profile/userprofile/SaledProductCard.jsx
+++ b/my-app/src/pages/profile/userprofile/SaledProductCard.jsx
@@ -77,7 +77,7 @@ const ItemPrice = styled.p`
     font-weight: 700;
     font-size: 12px;
     line-height: 15px;
-    color: var(--color-primary);
+    color: #3F7D9C;
 `;  
 
 


### PR DESCRIPTION
1. font-size: 18px 초과 & font-weight: bold -> 명암비(Contrast ratio) 3.0 이상
2. font-size: 18px 초과 -> 명암비(Contrast ratio) 4.5 이상
3. font-size: 18px 이하 & font-weight: bold -> 명암비(Contrast ratio) 4.5 이상
4. font-size: 18px 이하 -> 명암비(Contrast ratio) 7.0 이상

가격 text가 18px 이하, bold로 설정되어 있어서 명암비 4.5 이상 필요. 기존 색보다 살짝 어둡게 함.